### PR TITLE
CI first bits

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "Touch.Unit"]
+	path = Touch.Unit
+	url = git@github.com:spouliot/Touch.Unit.git

--- a/makefile
+++ b/makefile
@@ -1,0 +1,18 @@
+MDTOOL="/Applications/Xamarin Studio.app/Contents/MacOS/mdtool"
+MTOUCH=/Developer/MonoTouch/usr/bin/mtouch
+TOUCH_SERVER=./Touch.Unit/Touch.Server/bin/Debug/Touch.Server.exe
+
+all: build-simulator
+
+run run-test: run-simulator
+
+build-server:
+	cd Touch.Unit/Touch.Server && xbuild
+
+build-simulator:
+	$(MDTOOL) -v build -t:Build "-c:Debug|iPhoneSimulator" -p:Tests Rocks.sln
+
+run-simulator: build-simulator build-server
+	rm -f sim-results.log
+	mono --debug $(TOUCH_SERVER) --launchsim Tests/bin/iPhoneSimulator/Debug/Tests.app -autoexit -logfile=sim-results.log
+	cat sim-results.log


### PR DESCRIPTION
- Submodule Touch.Unit. Touch.Unit server is required to run tests on simulator
- Add make

Read [this blog post](https://spouliot.wordpress.com/2012/04/02/touch-unit-automation-revisited/) for more information.
